### PR TITLE
Supervisor config clarification

### DIFF
--- a/etc/supervisord.conf.example
+++ b/etc/supervisord.conf.example
@@ -1,7 +1,7 @@
 # Example supervisor configuration
 
 [inet_http_server]
-port = 9001
+port = 127.0.0.1:9001
 # For simple HTTP authentication of the admin panel
 username = emptysquare
 password = Password
@@ -14,7 +14,7 @@ childlogdir=%(here)s
 
 [supervisorctl]
 serverurl=http://localhost:9001
-username = admin
+username = emptysquare
 password = Password
 
 [rpcinterface:supervisor]


### PR DESCRIPTION
- When I have seted "9001" on `port` option of `[inet_http_server]` section, Supervisor raise the
  following exception:
  
  > Error: Could not determine IP address for hostname myhostname, please try setting an explicit IP address in the "port" setting of your [inet_http_server] section.  For example, instead of "port = 9001", try "port = 127.0.0.1:9001."
- The `username`/`password` combination of `[supervisorctl]` section should be the same of
  `[inet_http_server]` section.
