### PR TITLE
change the way to generate slug, fix delete category methods and category display.

### DIFF
--- a/motor_blog/text/slugify.py
+++ b/motor_blog/text/slugify.py
@@ -1,21 +1,18 @@
+# -*- coding: utf-8 -*-
 import sys
 import re
 from unicodedata import normalize
-
+from unidecode import unidecode
 reload(sys)
-sys.setdefaultencoding('utf-8');
-
+sys.setdefaultencoding("utf-8")
 # From http://flask.pocoo.org/snippets/5/, updated to mostly duplicate
 # Wordpress's slugs.
 _punct_re = re.compile(r'[\t !#$%&\()*\-/<=>?@\[\\\]^_`{|},:.+]+')
 
 
 def slugify(text, delim=u'-'):
+    """Generates an ASCII-only slug."""
     result = []
-    # Strip quotes.
-    text = text.decode("utf-8").replace("'", '').replace('"', '')
     for word in _punct_re.split(text.lower()):
-        word = normalize('NFKD', word.decode("utf-8"))
-        if word:
-            result.append(word)
+        result.extend(unidecode(word.decode("utf-8")).split())
     return unicode(delim.join(result))

--- a/motor_blog/web/admin.py
+++ b/motor_blog/web/admin.py
@@ -152,12 +152,12 @@ class DeleteCategoryHandler(MotorBlogAdminHandler):
     @gen.coroutine
     def post(self):
         category_slug = self.get_argument('category_slug')
-        result = yield self.db.categories.remove({'slug': category_slug})
+        result = yield self.settings['db'].categories.remove({'slug': category_slug})
 
         if not result.get('n'):
             raise tornado.web.HTTPError(404)
 
-        yield self.db.posts.update(
+        yield self.settings['db'].posts.update(
             {},
             {
                 # Hack: Set *all* posts' mod dates to now.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ git+git://github.com/SyrusAkbary/pyjade.git@a4db664b
 mock
 sockjs-tornado
 git+git://github.com/mirumee/google-measurement-protocol.git@34ded20d
+unidecode

--- a/theme/templates/category.jade
+++ b/theme/templates/category.jade
@@ -1,7 +1,7 @@
 extends base
 
 block vars
-    title = setting('author_display_name') + " | " + this_category.name
+    title = setting('author_display_name').decode("utf-8") + " | ".decode("utf-8") + this_category.name
     meta_description = setting('description')
     body_class = 'category-body multi-body'
 


### PR DESCRIPTION
I changed the way to slug generator, only generate ascii chars support by unidecode package and use the code from `http://flask.pocoo.org/snippets/5/`. 
category cannot delete because the attribute 'db' can't find. just modify the piece of code.